### PR TITLE
Add support for generating shared challenges with shared deployment templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,15 +577,14 @@ The following templates are required:
 - Challenge deployment templates:
   - Web: `instanced-web-k8s.yml`
   - TCP: `instanced-tcp-k8s.yml`
+  - Web: `shared-web-k8s.yml`
+  - TCP: `shared-tcp-k8s.yml`
 - [kube-ctf](https://github.com/ctfpilot/kube-ctf) deployment template:
   - `instanced-k8s-challenge.yml`
 
 **Configmap templates** are used to generate ConfigMaps for challenges and pages.  
 **Challenge deployment templates** are used to generate the Kubernetes deployment files for challenges.
 The **`kube-ctf` deployment template** is used to generate the deployment file for instanced challenges, when using the [kube-ctf](https://github.com/ctfpilot/kube-ctf) platform. Within this template, the challenge deployment template is embedded.
-
-> [!NOTE]
-> Only instanced templates are currently generated. Shared templates are not yet supported.
 
 ### Page structure
 

--- a/README.md
+++ b/README.md
@@ -575,10 +575,10 @@ The following templates are required:
   - `challenge-configmap.yml`
   - `page-configmap.yml`
 - Challenge deployment templates:
-  - Web: `instanced-web-k8s.yml`
-  - TCP: `instanced-tcp-k8s.yml`
-  - Web: `shared-web-k8s.yml`
-  - TCP: `shared-tcp-k8s.yml`
+  - Instanced web: `instanced-web-k8s.yml`
+  - Instanced TCP: `instanced-tcp-k8s.yml`
+  - Shared Web: `shared-web-k8s.yml`
+  - Shared TCP: `shared-tcp-k8s.yml`
 - [kube-ctf](https://github.com/ctfpilot/kube-ctf) deployment template:
   - `instanced-k8s-challenge.yml`
 

--- a/src/commands/challenge_creator.py
+++ b/src/commands/challenge_creator.py
@@ -147,7 +147,7 @@ class Args:
         else:
             challenge.set_min_points(args.min_points)
         
-        if (args.type == "instanced" or prompted_type == "instanced") and args.instanced_type == "none":
+        if ((args.type == "instanced" or prompted_type == "instanced") or (args.type == "shared" or prompted_type == "shared")) and args.instanced_type == "none":
             while True:
                 try:
                     challenge.set_instanced_type(input(f"Type of instanced challenge ({', '.join(INSTANCED_TYPES)}): ").lower())

--- a/src/commands/challenge_creator.py
+++ b/src/commands/challenge_creator.py
@@ -147,10 +147,10 @@ class Args:
         else:
             challenge.set_min_points(args.min_points)
         
-        if ((args.type == "instanced" or prompted_type == "instanced") or (args.type == "shared" or prompted_type == "shared")) and args.instanced_type == "none":
+        if (args.type in [ "instanced", "shared" ] or prompted_type in [ "instanced", "shared" ]) and args.instanced_type == "none":
             while True:
                 try:
-                    challenge.set_instanced_type(input(f"Type of instanced challenge ({', '.join(INSTANCED_TYPES)}): ").lower())
+                    challenge.set_instanced_type(input(f"Instanced type for challenge ({', '.join(INSTANCED_TYPES)}): ").lower())
                     break
                 except ValueError:
                     print("Invalid instanced type. Please try again.")

--- a/src/commands/challenge_creator.py
+++ b/src/commands/challenge_creator.py
@@ -154,6 +154,8 @@ class Args:
                     break
                 except ValueError:
                     print("Invalid instanced type. Please try again.")
+        elif args.instanced_type != "none":
+            challenge.set_instanced_type(args.instanced_type)
         else:
             challenge.set_instanced_type("none")
                 

--- a/src/library/generator.py
+++ b/src/library/generator.py
@@ -60,7 +60,12 @@ class Generator:
             
             self.dockerfile()
             
-            self.instanced_template_file()
+            if self.challenge.type == "shared":
+                self.shared_template_file()
+            elif self.challenge.type == "instanced":
+                self.instanced_template_file()
+            else:
+                print(f"Challenge type {self.challenge.type} not supported for template generation.")
 
     # --- Helper functions ---
     
@@ -266,14 +271,14 @@ This file should contain the steps to solve the challenge.""")
         return self.check_if_dir_exists(os.path.join(self.dir_template, "k8s.yml"))
     
     def instanced_template_file(self):
-        # Check if needed template exists
-        if not self.instanced_template_source_file_exists():
-            print("k8s template files not found!")
-            return False
-        
         # Check if template directory to write to exists
         if not self.check_if_dir_exists(self.dir_template):
             print("Template directory not found!")
+            return False
+        
+        # Check if needed template exists
+        if not self.instanced_template_source_file_exists():
+            print("Instanced k8s template files not found!")
             return False
         
         # Check if template file already exists
@@ -287,6 +292,46 @@ This file should contain the steps to solve the challenge.""")
             source_file = os.path.join(Utils.get_template_dir(), "instanced-tcp-k8s.yml")
         else:
             print(f"Instanced type {self.challenge.instanced_type} is not supported for instanced challenges.")
+            return False
+
+        output_file = os.path.join(self.dir_template, "k8s.yml")
+        with open(source_file, "r") as f:
+            with open(output_file, "w") as of:
+                of.write(f.read())
+        
+        print(f"File created: {output_file}")
+        
+        return True
+    
+    def shared_template_source_file_exists(self):
+        return self.check_if_dir_exists(os.path.join(Utils.get_template_dir(), "shared-web-k8s.yml")) and \
+               self.check_if_dir_exists(os.path.join(Utils.get_template_dir(), "shared-tcp-k8s.yml"))
+    
+    def shared_template_file_exists(self):
+        return self.check_if_dir_exists(os.path.join(self.dir_template, "k8s.yml"))
+    
+    def shared_template_file(self):
+        # Check if template directory to write to exists
+        if not self.check_if_dir_exists(self.dir_template):
+            print("Template directory not found!")
+            return False
+        
+        # Check if needed template exists
+        if not self.shared_template_source_file_exists():
+            print("Shared k8s template files not found!")
+            return False
+        
+        # Check if template file already exists
+        if self.shared_template_file_exists():
+            print("Template file already exists!")
+            return False
+        
+        if self.challenge.instanced_type == "web":
+            source_file = os.path.join(Utils.get_template_dir(), "shared-web-k8s.yml")
+        elif self.challenge.instanced_type == "tcp":
+            source_file = os.path.join(Utils.get_template_dir(), "shared-tcp-k8s.yml")
+        else:
+            print(f"Instanced type {self.challenge.instanced_type} is not supported for shared challenges.")
             return False
 
         output_file = os.path.join(self.dir_template, "k8s.yml")

--- a/template/instanced-tcp-k8s.yml
+++ b/template/instanced-tcp-k8s.yml
@@ -52,7 +52,7 @@ spec:
                     values:
                       - scaler
       containers:
-        - name: web
+        - name: tcp
           image: ghcr.io/{{ CHALLENGE_REPO }}-{{ DOCKER_IMAGE }}:{{ CHALLENGE_VERSION }}
           imagePullPolicy: IfNotPresent
           resources:

--- a/template/instanced-tcp-k8s.yml
+++ b/template/instanced-tcp-k8s.yml
@@ -87,6 +87,7 @@ spec:
   ports:
     - port: 8080
       name: tcp
+      targetPort: tcp
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP

--- a/template/shared-tcp-k8s.yml
+++ b/template/shared-tcp-k8s.yml
@@ -94,7 +94,7 @@ metadata:
     traefik.ingress.kubernetes.io/router.priority: "100"
 spec:
   entryPoints:
-    - tcp-test # Needs to be a custom entrypoint defined in Traefik - This is defined per challenge
+    - tcp-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }} # Needs to be a custom entrypoint defined in Traefik - This is defined per challenge
   routes:
     - match: HostSNI(`*`)
       priority: 10

--- a/template/shared-tcp-k8s.yml
+++ b/template/shared-tcp-k8s.yml
@@ -78,6 +78,7 @@ spec:
   ports:
     - port: 8080
       name: tcp
+      targetPort: tcp
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP

--- a/template/shared-tcp-k8s.yml
+++ b/template/shared-tcp-k8s.yml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+  namespace: kubectf-challenges
+  labels:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+    ctfpilot.com/component: "shared-challenge"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+      challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+      challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+  template:
+    metadata:
+      labels:
+        challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+        challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+        challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+        ctfpilot.com/component: "shared-challenge"
+    spec:
+      enableServiceLinks: false
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: dockerconfigjson-github-com
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1
+          - 8.8.8.8
+      tolerations:
+        - key: "cluster.ctfpilot.com/node"
+          value: "scaler"
+          effect: "PreferNoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "cluster.ctfpilot.com/node"
+                    operator: In
+                    values:
+                      - scaler
+      containers:
+        - name: web
+          image: ghcr.io/{{ CHALLENGE_REPO }}-{{ DOCKER_IMAGE }}:{{ CHALLENGE_VERSION }}
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          ports:
+            - containerPort: 8080
+              name: tcp
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "ctf-{{ deployment_id }}"
+  namespace: kubectf-challenges
+  labels:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+    ctfpilot.com/component: "shared-challenge"
+spec:
+  selector:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+  ports:
+    - port: 8080
+      name: tcp
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: "chall-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+  namespace: kubectf-challenges
+  labels:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+    ctfpilot.com/component: "shared-challenge"
+  annotations:
+    traefik.ingress.kubernetes.io/router.priority: "100"
+spec:
+  entryPoints:
+    - tcp-test # Needs to be a custom entrypoint defined in Traefik - This is defined per challenge
+  routes:
+    - match: HostSNI(`*`)
+      priority: 10
+      middlewares:
+        - name: challenge-ipwhitelist-tcp
+          namespace: kubectf-challenges
+      services:
+        - name: "chall-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+          port: 8080

--- a/template/shared-tcp-k8s.yml
+++ b/template/shared-tcp-k8s.yml
@@ -46,7 +46,7 @@ spec:
                     values:
                       - scaler
       containers:
-        - name: web
+        - name: tcp
           image: ghcr.io/{{ CHALLENGE_REPO }}-{{ DOCKER_IMAGE }}:{{ CHALLENGE_VERSION }}
           imagePullPolicy: IfNotPresent
           resources:

--- a/template/shared-tcp-k8s.yml
+++ b/template/shared-tcp-k8s.yml
@@ -63,7 +63,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "ctf-{{ deployment_id }}"
+  name: "ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
   namespace: kubectf-challenges
   labels:
     challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
@@ -82,7 +82,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
-  name: "chall-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+  name: "ingress-ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
   namespace: kubectf-challenges
   labels:
     challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
@@ -101,5 +101,5 @@ spec:
         - name: challenge-ipwhitelist-tcp
           namespace: kubectf-challenges
       services:
-        - name: "chall-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+        - name: "ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
           port: 8080

--- a/template/shared-web-k8s.yml
+++ b/template/shared-web-k8s.yml
@@ -116,6 +116,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}
+                name: "ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
                 port:
                   number: 80

--- a/template/shared-web-k8s.yml
+++ b/template/shared-web-k8s.yml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+  namespace: kubectf-challenges
+  labels:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+    ctfpilot.com/component: "shared-challenge"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+      challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+      challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+  template:
+    metadata:
+      labels:
+        challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+        challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+        challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+        ctfpilot.com/component: "shared-challenge"
+    spec:
+      enableServiceLinks: false
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: dockerconfigjson-github-com
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1
+          - 8.8.8.8
+      tolerations:
+        - key: "cluster.ctfpilot.com/node"
+          value: "scaler"
+          effect: "PreferNoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: "cluster.ctfpilot.com/node"
+                    operator: In
+                    values:
+                      - scaler
+      containers:
+        - name: web
+          image: ghcr.io/{{ CHALLENGE_REPO }}-{{ DOCKER_IMAGE }}:{{ CHALLENGE_VERSION }}
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+          ports:
+            - containerPort: 80
+              name: web-port
+          startupProbe:
+            httpGet:
+              path: /
+              port: web-port
+            failureThreshold: 12
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: web-port
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+  namespace: kubectf-challenges
+  labels:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+    ctfpilot.com/component: "shared-challenge"
+spec:
+  selector:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+  ports:
+    - port: 80
+      targetPort: web-port
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "ingress-ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
+  namespace: kubectf-challenges-shared
+  labels:
+    challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
+    challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"
+    challenges.ctfpilot.com/category: "{{ CHALLENGE_CATEGORY }}"
+    ctfpilot.com/component: "shared-challenge"
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: kubectf-instancing-fallback@kubernetescrd
+spec:
+  tls:
+    - hosts:
+        - "{{ CHALLENGE_NAME }}.{{ .Values.kubectf.host }}"
+      secretName: kubectf-cert-challs
+  rules:
+    - host: "{{ CHALLENGE_NAME }}.{{ .Values.kubectf.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}
+                port:
+                  number: 80

--- a/template/shared-web-k8s.yml
+++ b/template/shared-web-k8s.yml
@@ -95,7 +95,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "ingress-ctf-{{ CHALLENGE_CATEGORY }}-{{ CHALLENGE_NAME }}"
-  namespace: kubectf-challenges-shared
+  namespace: kubectf-challenges
   labels:
     challenges.ctfpilot.com/type: "{{ CHALLENGE_TYPE }}"
     challenges.ctfpilot.com/name: "{{ CHALLENGE_NAME }}"


### PR DESCRIPTION
This updates add shared deployment templates for both web and TCP `instanced_type` challenges.