### PR TITLE
Ensure lowercase repository name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: Release
-    uses: ctfpilot/ci/.github/workflows/release.yml@v1.5.0-r.2
+    uses: ctfpilot/ci/.github/workflows/release.yml@v1.5.0
     permissions:
       contents: write
       packages: write

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "challenge-toolkit"
-version = "2.0.0"
+version = "2.0.1rc1"
 description = "CTF Pilot's Challenge Toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/challenge_toolkit/commands/template_renderer.py
+++ b/src/challenge_toolkit/commands/template_renderer.py
@@ -60,6 +60,10 @@ class Args:
         if not self.repo or self.repo.strip() == "":
             print("GitHub repository is required. Please provide it via the --repo argument or the GITHUB_REPOSITORY environment variable.")
             sys.exit(1)
+            
+        # Ensure lowercase repo, as it is used within container image templating
+        # Github repository names are case-insensitive, but Docker image names are case-sensitive and must be lowercase.
+        self.repo = self.repo.lower()
 
     def __getattr__(self, name):
         return getattr(self.args, name)

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "challenge-toolkit"
-version = "2.0.0"
+version = "2.0.1rc1"
 source = { editable = "." }
 dependencies = [
     { name = "python-slugify" },
@@ -39,7 +39,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
This update provides a small fix to the repo argument input, where it automatically makes it lower case.  
This is due to Github usernames and organisations may have uppercase letters, but Docker images, which the arugment is used for templating, must be lowercase.

This update therefore forces repo input to always be lowercase.